### PR TITLE
[Fix] Compatibility between Roman alphabet forms

### DIFF
--- a/GameSystem.py
+++ b/GameSystem.py
@@ -653,10 +653,11 @@ class GameInfo:
             return False
 
         if not Romautil.is_halfway(self.target_kana, self.target_roma):
-            first_character = self.target_kana[:1]
-            kunrei = romkan.to_kunrei(first_character)
-            hepburn = romkan.to_hepburn(first_character)
-            optimized = Romautil.hira2roma(first_character)
+
+            first_syllable = Romautil.get_first_syllable(self.target_kana)
+            kunrei = romkan.to_kunrei(first_syllable)
+            hepburn = romkan.to_hepburn(first_syllable)
+            optimized = Romautil.hira2roma(first_syllable)
 
             if kunrei[0] == "x":
                 return self.is_exactly_expected_key(code)

--- a/Romautil.py
+++ b/Romautil.py
@@ -64,12 +64,17 @@ def get_not_halfway_hr(full_hiragana, progress_roma):
     :param progress_roma: ローマ字
     """
 
+    # 空文字なら空文字を返す
     if len(progress_roma) == 0: return ""
-    romaji = hira2roma(full_hiragana)
 
+    # 全体のひらがなに対し、どこまで打っているのかを見る
+    romaji = hira2roma(full_hiragana)
     index = romaji.rfind(progress_roma)
 
-    if re.match("[aeiouyn]", romaji[index]) and romkan.is_consonant(romaji[index - 1]):
+    # 今母音を打とうとしていて、かつ直前に子音を打っている (taやhaなどに引っかかる)
+    if re.match("[aeiouyn]", romaji[index]) or romkan.is_consonant(romaji[index - 1]):
+
+        # 3文字で構成されるローマ表記の文字を打っているか (tyaやhyuなどに引っかかる)
         if index >= 2 and romkan.is_consonant(romaji[index - 2]):
             return romkan.to_hiragana(romaji[index - 2:])[1:]
         else:
@@ -87,3 +92,21 @@ def is_halfway(hiragana, english):
     :return: 中途半端であった場合はTrueを返す。
     """
     return hira2roma(get_not_halfway_hr(hiragana, english))[:1] != hira2roma(english)[:1]
+
+
+def get_first_syllable(hiragana):
+    """
+    ひらがなの最初の音節を取得する。
+    hiraganaが「へびのめ」なら「へ」、「じゃのめ」なら「じゃ」を返す。
+
+    :param hiragana: ひらがな。
+    :return: 最初の音節。
+    """
+
+    if len(hiragana) < 2:
+        return hiragana
+
+    if re.match("[ゃゅょ]", hiragana[1]):
+        return hiragana[:2]
+    else:
+        return hiragana[:1]


### PR DESCRIPTION
訓令式で3文字必要な文字を、2文字でタイプしたときに発生するバグを修正。

e.g.) `zya`を`ja`とタイプするために、`j`とタイプした場合、
　　「`zy`」と「`a`」、「`じ`」と「`ゃ`」に処理が分かれてしまい、
　　「`jia`」と表記されてしまう。

これにより正しいローマ字の表示ができなくなり、 #41 のバグが発生する。加えて正しく入力してもMiss判定になってしまう。